### PR TITLE
Yarn runner + service option for package.json script name

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,13 @@ If you use `yarn` you can configure the `runnerType` service option:
     ]
 ```
 
+If you already have a linter script that you would like to reuse (instead of `eslint`), you can configure the `scriptName` service option:
+
+```javascript
+    services: [
+        ['eslinter', { scriptName: 'eslint:check' }]
+    ]
+```
 
 ## Using in WebdriverIO
 

--- a/README.md
+++ b/README.md
@@ -68,6 +68,14 @@ Lastly, add the `eslinter` service to the services array in `wdio.conf.js`:
 
 Run `npm run eslint` to verify and check for errors.
 
+If you use `yarn` you can configure the `runnerType` service option:
+
+```javascript
+    services: [
+        ['eslinter', { runnerType: 'yarn' }]
+    ]
+```
+
 
 ## Using in WebdriverIO
 

--- a/src/eslint-npm-runner.js
+++ b/src/eslint-npm-runner.js
@@ -2,10 +2,10 @@
 
 const { spawn } = require('child_process');
 
-module.exports = function () {
+module.exports = function (scriptName) {
     return new Promise((resolve, reject) => {
         const npmCmd = process.platform.match('^win') !== null ? 'npm.cmd' : 'npm';
-        const eslint = spawn(npmCmd, ['run', 'eslint', '--silent'], { stdio: "inherit" });
+        const eslint = spawn(npmCmd, ['run', scriptName, '--silent'], { stdio: "inherit" });
 
         eslint.on('close', (code) => {
             if (code !== 0)

--- a/src/eslint-yarn-runner.js
+++ b/src/eslint-yarn-runner.js
@@ -5,7 +5,7 @@ const { spawn } = require('child_process');
 module.exports = function (scriptName) {
     return new Promise((resolve, reject) => {
         const yarnCmd = process.platform.match('^win') !== null ? 'yarn.cmd' : 'yarn';
-        const eslint = spawn(yarnCmd, [scriptName, '--quiet'], { stdio: "inherit" });
+        const eslint = spawn(yarnCmd, ['run', '--silent', scriptName], { stdio: "inherit" });
 
         eslint.on('close', (code) => {
             if (code !== 0)

--- a/src/eslint-yarn-runner.js
+++ b/src/eslint-yarn-runner.js
@@ -1,0 +1,17 @@
+// eslint-yarn-runner.js
+
+const { spawn } = require('child_process');
+
+module.exports = function (scriptName) {
+    return new Promise((resolve, reject) => {
+        const yarnCmd = process.platform.match('^win') !== null ? 'yarn.cmd' : 'yarn';
+        const eslint = spawn(yarnCmd, [scriptName, '--quiet'], { stdio: "inherit" });
+
+        eslint.on('close', (code) => {
+            if (code !== 0)
+                reject(code);
+            else
+                resolve(code);
+        });
+    });
+}

--- a/src/launcher.js
+++ b/src/launcher.js
@@ -7,6 +7,8 @@ class EslintLauncherService {
         this.options = serviceOptions ? serviceOptions : {}
         if(!this.options.runnerType)
             this.options.runnerType = 'npm';
+        if(!this.options.scriptName)
+            this.options.scriptName = 'eslint';
         logger.warn(`initialize wdio-eslinter-service using ${this.options.runnerType} runner.`)
     }
 
@@ -14,7 +16,7 @@ class EslintLauncherService {
         return new Promise((resolve, reject) => {
             const { SevereServiceError } = require('webdriverio')
             const runEslint = require(`./eslint-${this.options.runnerType}-runner`)
-            return runEslint().then((code) => {
+            return runEslint(this.options.scriptName).then((code) => {
                 logger.info('eslint checks passed...')
                 resolve()
             }).catch((err) => {


### PR DESCRIPTION
@jamesmortensen thank you for implementing this service!

This pull request adds support for:
- a `yarn` runner
- a service option to allow specifying a script name other than `eslint`

Motivation behind this change:
- using `yarn` as a package manager
- reusing an existing `package.json` script for linting code (and currently being used in multiple CI projects)

How we're using it:
```typescript
export const config: WebdriverIO.Config = {
  ...,
  services: [
    [
      'eslinter',
      {
        runnerType: 'yarn',
        scriptName: 'lint:check',
      }
    ]
  ],
  ...
}
```